### PR TITLE
feat(query): improve unique orderBy error message

### DIFF
--- a/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
+++ b/packages/graphile-build-pg/src/queryFromResolveDataFactory.js
@@ -310,10 +310,12 @@ exists(
         queryBuilder.whereBound(sql.fragment`false`, isAfter);
       }
       const orderByExpressionsAndDirections = queryBuilder.getOrderByExpressionsAndDirections();
-      if (
-        orderByExpressionsAndDirections.length > 0 &&
-        queryBuilder.isOrderUnique()
-      ) {
+      if (orderByExpressionsAndDirections.length > 0) {
+        if (!queryBuilder.isOrderUnique()) {
+          throw new Error(
+            'The cursor requires a primary key or an unique key combination for orderBy clause'
+          )
+        }
         const rawPrefixes = cursorValue.slice(0, cursorValue.length - 1);
         const rawCursors = cursorValue[cursorValue.length - 1];
         if (rawPrefixes.length !== getPgCursorPrefix().length) {


### PR DESCRIPTION
When using cursor for pagination (```before``` and ```after```) Graphile requires that the ```orderBy``` clause must be composed of unique value, either referring the table PK or mixing values that returns a unique result.

Currently when the query fails due to that error the message that returns is ```Cannot use cursors without orderBy```, which is misleading, because there might be an ```orderBy``` clause passed, but it's not correctly assigned.

This PR uses a validation that already exists in the codebase and throws an error message based on the flag returned from it.